### PR TITLE
:bug: getImageBase64を修正する Fixes #24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "^1.6.2",
         "axios": "^0.24.0",
         "graphql": "^16.3.0",
+        "just-split": "^3.2.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-joyride": "^2.4.0",
@@ -1338,7 +1339,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -1406,7 +1408,8 @@
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.19.tgz",
       "integrity": "sha512-L37dSCT0aoJnCgpR8Iuginlbxoh7qhWOXiaDqEsxVMrER1CmVhFD+63NxgJeT4pkmEM28oX0NH4S4f+sXHTZjA==",
-      "devOptional": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -3879,6 +3882,11 @@
         "css-vendor": "^2.0.8",
         "jss": "10.9.2"
       }
+    },
+    "node_modules/just-split": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/just-split/-/just-split-3.2.0.tgz",
+      "integrity": "sha512-hh57dN5koTBkmg3T6gBFISVVaW5bgZ6Ct1W5KODD5M7hQJKqGzTKkfMwOil8MBxyztLQEjh/v6UGXE8cP5tnqQ=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@reduxjs/toolkit": "^1.6.2",
     "axios": "^0.24.0",
     "graphql": "^16.3.0",
+    "just-split": "^3.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-joyride": "^2.4.0",

--- a/src/popup/components/AppRoot.tsx
+++ b/src/popup/components/AppRoot.tsx
@@ -23,7 +23,6 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { GET_PULL_REQUESTS } from "../../apollo/queries";
 import {
-  getImageBase64,
   getTargetRepositories,
   removeDuplicateFromObjectArray,
 } from "../../utils";
@@ -120,6 +119,7 @@ export function AppRoot() {
   }, [data]);
 
   const filterableAuthors = isMe ? requestedAuthors : allAuthors;
+
   return (
     <Grid container sx={{ minWidth: 500 }}>
       {!data && !loading && <Joyride steps={steps} continuous={true} />}
@@ -165,7 +165,6 @@ export function AppRoot() {
                       src={author.avatarUrl}
                       sx={
                         (console.log(queryAuthor, authorName),
-                        getImageBase64(author.avatarUrl),
                         queryAuthor === authorName
                           ? {
                               border: "1px solid!important;",

--- a/src/popup/components/AppRoot.tsx
+++ b/src/popup/components/AppRoot.tsx
@@ -23,6 +23,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import Switch from "@mui/material/Switch";
 import { GET_PULL_REQUESTS } from "../../apollo/queries";
 import {
+  getImageBase64,
   getTargetRepositories,
   removeDuplicateFromObjectArray,
 } from "../../utils";
@@ -119,7 +120,6 @@ export function AppRoot() {
   }, [data]);
 
   const filterableAuthors = isMe ? requestedAuthors : allAuthors;
-
   return (
     <Grid container sx={{ minWidth: 500 }}>
       {!data && !loading && <Joyride steps={steps} continuous={true} />}
@@ -165,6 +165,7 @@ export function AppRoot() {
                       src={author.avatarUrl}
                       sx={
                         (console.log(queryAuthor, authorName),
+                        getImageBase64(author.avatarUrl),
                         queryAuthor === authorName
                           ? {
                               border: "1px solid!important;",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import split from "just-split";
 import { Repository } from "../types/options";
 
 export const getTargetRepositories = async (): Promise<string[]> => {
@@ -19,9 +20,12 @@ export const getImageBase64 = async (url: string) => {
   const response = await fetch(url);
   const contentType = response.headers.get("content-type");
   const arrayBuffer = await response.arrayBuffer();
-  let base64String = btoa(
-    String.fromCharCode.apply(null, new Uint8Array(arrayBuffer) as any)
-  );
+  const uint8Array = [...new Uint8Array(arrayBuffer)];
+  // https://www.npmjs.com/package/just-split
+  const encoded = split(uint8Array, 1024)
+    .map((chunk) => String.fromCharCode(...chunk))
+    .reduce((previous, current) => previous + current, "");
+  const base64String = window.btoa(encoded);
   return `data:${contentType};base64,${base64String}`;
 };
 


### PR DESCRIPTION
-  #24

上記Issueで指摘した2点を修正しています。

`uint8Array`を小さく分けて処理する方法については、[Just](https://github.com/angus-c/just)というライブラリーの`just-split`を使用して関数型プログラミングのスタイルで書いています。

JustはLodashのようなユーティリティ・ライブラリーですが、次のような特徴があります。
- zero-dependency: Just内部の関数同士ですら互いに依存していません。
- 非常に軽量: 1つごとにインストールするスタイルであるためバンドルサイズの肥大化を防ぎます。
- [いつでも簡単に読める](https://github.com/angus-c/just/blob/master/packages/array-split/index.cjs): 上記2点の恩恵により非常にコードが短く、他のファイルを読みにいく必要もありません。勉強になります。

<img width="651" alt="スクリーンショット 2023-02-12 23 29 26" src="https://user-images.githubusercontent.com/2579373/218318600-2faafa4c-4a45-456d-b83b-f572005708d7.png">

上記コードにてエラーが発生しないこと、また `btoa` についてはVSCode上でdeprecated扱いの打ち消し線が表示されないことを確認済みです。

以上、レビューよろしくお願いします。