### PR TITLE
:recycle: removeDuplicateFromObjectArrayの修正 Fixes #26

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -46,15 +46,10 @@ export const isNotifyTarget = (
   return duration * 60 > progressSecond;
 };
 
-export const removeDuplicateFromObjectArray =
-  (key: string) =>
-  (objectArray: object[]): any => {
-    return Array.from(
-      objectArray
-        .reduce(
-          (map: any, current: any) => map.set(current[key], current),
-          new Map()
-        )
-        .values()
-    );
-  };
+export const uniqueByKey = <T, K extends keyof T>(array: T[], key: K): T[] => {
+  const map = array.reduce(
+    (m, current) => m.set(current[key], current),
+    new Map<T[K], T>()
+  );
+  return Array.from(map.values());
+};


### PR DESCRIPTION
関数`removeDuplicateFromObjectArray`について以下の点を修正しました。

- removeDuplicate => unique として、関数名を短く`uniqueByKey`に修正
- カリー化をやめて、第一引数にオブジェクトの配列を渡すと、第二引数の推論が働くように
- Mapのコンストラクターに型を渡して`as`を回避しつつ正しい戻り値の型を設定

`any`型だったauthorsを次のように定義した`Author[]`型にして、uniqueByKeyの第二引数が正しく推論されることを確認済みです。

```typescript
type Author = { login: string };
```

<img width="864" alt="image" src="https://user-images.githubusercontent.com/2579373/218321760-5c77b6e8-1383-459d-8e74-0306de451e3a.png">

以上、レビューよろしくお願いします。