### PR TITLE
型ガードで安全にストレージデータに型付け

### DIFF
--- a/.commit_template
+++ b/.commit_template
@@ -5,7 +5,7 @@
 # 👍  :+1: Feature improvements
 # ✨  :sparkles: Additional partial feature
 # 🎉  :tada: Grand major features added to celebrate
-# ♻️   :recycle :Refactoring
+# ♻️   :recycle: Refactoring
 # 🚿  :shower: Removal of obsolete functions or features.
 # 💚  :green_heart: Modification and improvement of testing and CI
 # 👕  :shirt: Fixing of errors found by Lint.

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,7 +1,11 @@
+const repositoryKeys = ["isShow", "name"] as const;
 export type Repository = {
   isShow: boolean;
   name: string;
 };
+
+export const isRepository = (value: object): value is Repository =>
+  repositoryKeys.every((key) => Object.keys(value).includes(key));
 
 export const DELAY_MINUTES: number = 1;
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,8 +1,8 @@
-const repositoryKeys = ["isShow", "name"] as const;
 export type Repository = {
   isShow: boolean;
   name: string;
 };
+const repositoryKeys: (keyof Repository)[] = ["isShow", "name"];
 
 export const isRepository = (value: object): value is Repository =>
   repositoryKeys.every((key) => Object.keys(value).includes(key));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,14 +1,18 @@
 import split from "just-split";
-import { Repository } from "../types/options";
+import { isRepository } from "../types/options";
 
-export const getTargetRepositories = async (): Promise<string[]> => {
-  const repos = await chrome.storage.sync.get("repositories");
-  const targetRepos = repos["repositories"]
-    ? repos["repositories"]
-        .map((o: Repository) => o.isShow && o.name)
-        .join(" repo:")
-    : "";
-  return targetRepos;
+export const getTargetRepositories = async (): Promise<string> => {
+  const repos = await chrome.storage.sync
+    .get("repositories")
+    .then((storage) => {
+      const repositories = storage["repositories"];
+      if (!Array.isArray(repositories)) return [];
+      return repositories.filter(isRepository);
+    });
+  return repos
+    .filter(({ isShow }) => isShow)
+    .map(({ name }) => name)
+    .join(" repo:");
 };
 
 /**


### PR DESCRIPTION
## 内容
![image](https://user-images.githubusercontent.com/2579373/220386194-9478be85-857c-4077-80d4-10acf7d054f2.png)
`isRepository`による型ガードで、型ヒントが適切に表示されるようになりました。

また、追加でコミットテンプレートにフォーマットのミスを発見したので修正しています。

## 課題
`repositoryKeys`配列と`Repository`型の関連における安全性は、やや弱めです。

```typescript
export type Repository = {
  isShow: boolean;
  name: string;
};

const repositoryKeys: (keyof Repository)[] = ["isShow", "name"];

export const isRepository = (value: object): value is Repository =>
  repositoryKeys.every((key) => Object.keys(value).includes(key));
```

項目が2つなので列挙の漏れは発生しませんが、5つ以上になってくると危ないですね。
[zod](https://github.com/colinhacks/zod) を導入することで `isRepository` はより安全にスッキリと記述出来るので、別途Issueにさせてください。


